### PR TITLE
Implement full-stack finance suite skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: finance
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+      - name: Run tests
+        run: |
+          python -m pytest backend/tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# finance-suite
+# Finance Suite
+
+This is a minimal full-stack example using **FastAPI**, **SQLModel**, **PostgreSQL**, **React** (with TypeScript, Vite and Chakra UI) and **Docker Compose**. It includes utilities to estimate German net salary and IG Metall tariff incomes.
+
+## Development
+
+Requirements: Docker and Docker Compose.
+
+Start the stack for development:
+
+```bash
+docker compose up --build
+```
+
+The backend will be available at `http://localhost:8000`, the frontend at `http://localhost:8877` via Traefik.
+
+Run tests locally with:
+
+```bash
+pip install -r backend/requirements.txt
+python -m pytest backend/tests
+```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends, HTTPException
+from . import schemas
+from .payroll import gross_to_net, PayrollInputData, net_to_gross
+from .tarif import berechne_nrw_2025, TarifInputData, get_monthly_breakdown
+
+router = APIRouter()
+
+@router.post("/payroll/gross-to-net", response_model=schemas.PayrollResult)
+def api_gross_to_net(data: schemas.PayrollInput):
+    pdata = PayrollInputData(**data.dict())
+    result = gross_to_net(pdata)
+    return result.asdict()
+
+@router.post("/payroll/net-to-gross")
+def api_net_to_gross(data: schemas.PayrollInput):
+    target_net = data.gross
+    pdata = PayrollInputData(**data.dict())
+    gross, result = net_to_gross(target_net, **pdata.__dict__)
+    return {"gross": gross, **result.asdict()}
+
+@router.post("/tarif/estimate", response_model=schemas.TarifResult)
+def api_tarif_estimate(data: schemas.TarifInput):
+    tdata = TarifInputData(**data.dict())
+    return berechne_nrw_2025(tdata).asdict()
+
+@router.post("/tarif/breakdown", response_model=list[schemas.MonthlyBreakdown])
+def api_tarif_breakdown(data: schemas.TarifInput):
+    tdata = TarifInputData(**data.dict())
+    return get_monthly_breakdown(tdata)

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,26 @@
+from passlib.context import CryptContext
+from jose import JWTError, jwt
+from datetime import datetime, timedelta
+from typing import Optional
+
+SECRET_KEY = "secret"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,11 @@
+from sqlmodel import SQLModel, create_engine
+from sqlalchemy.orm import sessionmaker
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@db:5432/finance")
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def init_db():
+    SQLModel.metadata.create_all(engine)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from .api import router
+
+app = FastAPI(title="Finance Suite API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(router, prefix="/api")
+
+@app.get("/")
+def read_root():
+    return {"message": "Finance Suite API"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+from typing import Optional
+from sqlmodel import SQLModel, Field
+
+class User(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    email: str = Field(index=True, unique=True)
+    hashed_password: str
+    is_active: bool = True
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/payroll.py
+++ b/backend/app/payroll.py
@@ -1,0 +1,128 @@
+"""Payroll calculator for German net salary estimation (2025)."""
+from dataclasses import dataclass, asdict
+from typing import Dict, Tuple
+
+# ---------------- 1  Konstanten ----------------
+BASIC_ALLOWANCE = 12_096
+ZONE1_END, ZONE2_END, ZONE3_END = 17_443, 68_480, 277_825
+
+SOLI_FREE_SINGLE, SOLI_FREE_MARRIED, SOLI_RATE = 19_950, 39_900, .055
+
+KIST_BY_STATE = {"BY": .09, "BW": .09, **{k: .08 for k in
+    "NW NI HB HH HE RP SL SH MV SN ST BB BE TH".split()}}
+
+KV_GENERAL, KV_AVG_ADD = .146, .025
+PV_BASE, PV_CHILDLESS_SURCH = .036, .006
+RV_RATE, AV_RATE = .186, .026
+
+BBG_KV_PV, BBG_RV_AV = 5_512.50, 8_050.00
+
+WK_PAUSCHALE, SONDERAUSG_PAUS, VSP_MAX_RATE = 1_230, 36, .20
+
+# --------------- 2  Steuerfunktionen ----------
+def income_tax(zve: float) -> float:
+    if zve <= BASIC_ALLOWANCE:
+        return 0.0
+    if zve <= ZONE1_END:
+        y = (zve - BASIC_ALLOWANCE) / 10_000
+        return (932.3 * y + 1_400) * y
+    if zve <= ZONE2_END:
+        z = (zve - ZONE1_END) / 10_000
+        return (176.64 * z + 2_397) * z + 1_015.13
+    if zve <= ZONE3_END:
+        return 0.42 * zve - 10_911.92
+    return 0.45 * zve - 19_246.67
+
+def soli(tax: float, married: bool=False) -> float:
+    free = SOLI_FREE_MARRIED if married else SOLI_FREE_SINGLE
+    if tax <= free:
+        return 0.0
+    diff = tax - free
+    return min(0.19945 * diff, SOLI_RATE * tax) if diff < 1_000 else SOLI_RATE * tax
+
+# --------------- 3  Datenklassen -------------
+@dataclass
+class PayrollInputData:
+    gross: float
+    period: str = "monthly"          # 'monthly' | 'yearly'
+    tax_class: int = 1
+    married: bool = False
+    federal_state: str = "NW"
+    church: bool = False
+    childless: bool = True
+    additional_kv: float = KV_AVG_ADD
+
+@dataclass
+class PayrollResultData:
+    net: float
+    income_tax: float
+    solidarity: float
+    church_tax: float
+    health_employee: float
+    health_employer: float
+    care_employee: float
+    care_employer: float
+    pension_employee: float
+    pension_employer: float
+    unemployment_employee: float
+    unemployment_employer: float
+    def asdict(self) -> Dict:
+        return asdict(self)
+
+# --------------- 4  Hauptfunktion -----------
+def gross_to_net(data: PayrollInputData) -> PayrollResultData:
+    m_gross = data.gross if data.period == "monthly" else data.gross / 12
+    a_gross = m_gross * 12
+
+    # Sozialversicherung
+    kv_rate = KV_GENERAL + data.additional_kv
+    kv_emp = kv_ag = min(m_gross, BBG_KV_PV) * kv_rate / 2
+
+    pv_emp = pv_ag = min(m_gross, BBG_KV_PV) * PV_BASE / 2
+    if data.childless:                              # Zuschlag mit BBG-Deckel!
+        pv_emp += min(m_gross, BBG_KV_PV) * PV_CHILDLESS_SURCH
+
+    rv_emp = rv_ag = min(m_gross, BBG_RV_AV) * RV_RATE / 2
+    av_emp = av_ag = min(m_gross, BBG_RV_AV) * AV_RATE / 2
+
+    sv_emp_annual = 12 * (kv_emp + pv_emp + rv_emp + av_emp)
+    vsp = min(sv_emp_annual, VSP_MAX_RATE * a_gross)
+
+    # Steuer
+    zvE = a_gross - vsp - WK_PAUSCHALE - SONDERAUSG_PAUS
+    tax_y = income_tax(max(0, zvE))
+    if   data.tax_class == 3: tax_y = 2 * income_tax(zvE / 2)
+    elif data.tax_class == 5: tax_y *= 1.20
+    elif data.tax_class == 6: tax_y *= 1.30
+
+    tax_m  = tax_y / 12
+    soli_m = soli(tax_y, data.married) / 12
+    kist_m = tax_m * KIST_BY_STATE[data.federal_state] if data.church else 0.0
+
+    deductions = tax_m + soli_m + kist_m + kv_emp + pv_emp + rv_emp + av_emp
+    net_m = m_gross - deductions
+    net   = net_m if data.period == "monthly" else net_m * 12
+
+    return PayrollResultData(
+        net=round(net, 2),
+        income_tax=round(tax_m if data.period == "monthly" else tax_y, 2),
+        solidarity=round(soli_m if data.period == "monthly" else soli_m * 12, 2),
+        church_tax=round(kist_m if data.period == "monthly" else kist_m * 12, 2),
+        health_employee=round(kv_emp, 2),
+        health_employer=round(kv_ag, 2),
+        care_employee=round(pv_emp, 2),
+        care_employer=round(pv_ag, 2),
+        pension_employee=round(rv_emp, 2),
+        pension_employer=round(rv_ag, 2),
+        unemployment_employee=round(av_emp, 2),
+        unemployment_employer=round(av_ag, 2),
+    )
+
+def net_to_gross(target_net: float, **kwargs) -> Tuple[float, PayrollResultData]:
+    lo, hi = 0.0, target_net * 3
+    result = None
+    for _ in range(25):
+        mid = (lo + hi) / 2
+        result = gross_to_net(PayrollInputData(gross=mid, **kwargs))
+        hi, lo = (mid, lo) if result.net > target_net else (hi, mid)
+    return round(hi, 2), result

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,59 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+# Payroll schemas derived from payroll calculator
+class PayrollInput(BaseModel):
+    gross: float
+    period: str = "monthly"
+    tax_class: int = 1
+    married: bool = False
+    federal_state: str = "NW"
+    church: bool = False
+    childless: bool = True
+    additional_kv: float = 0.025
+
+class PayrollResult(BaseModel):
+    net: float
+    income_tax: float
+    solidarity: float
+    church_tax: float
+    health_employee: float
+    health_employer: float
+    care_employee: float
+    care_employer: float
+    pension_employee: float
+    pension_employer: float
+    unemployment_employee: float
+    unemployment_employer: float
+
+class TarifInput(BaseModel):
+    entgeltgruppe: str
+    stufe: str
+    wochenstunden: float = 35
+    leistungszulage_pct: float = 0.0
+    sonstige_zulage_pct: float = 0.0
+    tzug_b_pct: float = 18.5
+    urlaubsgeld_pct: float = 72.0
+    transformationsgeld_pct: float = 18.4
+    tzug_a_pct: float = 27.5
+    weihnachtsgeld_pct_base: float = 25.0
+    weihnachtsgeld_pct_max: float = 55.0
+    betriebszugehoerigkeit_monate: int = 0
+    include_transformationsgeld: bool = True
+
+class TarifResult(BaseModel):
+    monatsgrund: float
+    zulagen: float
+    monatsgesamt: float
+    tzug_b: float
+    urlaubsgeld: float
+    transformationsgeld: float
+    tzug_a: float
+    weihnachtsgeld: float
+    jahresentgelt: float
+
+class MonthlyBreakdown(BaseModel):
+    Monat: str
+    Brutto: float
+    Bestandteile: str
+

--- a/backend/app/tarif.py
+++ b/backend/app/tarif.py
@@ -1,0 +1,143 @@
+"""IG Metall NRW 2025 tariff calculator."""
+from dataclasses import dataclass, asdict
+from typing import Dict, List, Any
+
+TARIF_NRW_2025: Dict[str, Dict[str, float]] = {
+    "EG 1":  {"Grundentgelt": 2_705.00},
+    "EG 2":  {"Grundentgelt": 2_738.00},
+    "EG 3":  {"Grundentgelt": 2_769.50},
+    "EG 4":  {"Grundentgelt": 2_812.50},
+    "EG 5":  {"Grundentgelt": 2_871.50},
+    "EG 6":  {"Grundentgelt": 2_946.00},
+    "EG 7":  {"Grundentgelt": 3_038.00},
+    "EG 8":  {"Grundentgelt": 3_196.00},
+    "EG 9":  {"Grundentgelt": 3_454.00},
+    "EG 10": {"Grundentgelt": 3_796.50},
+    "EG 11": {"Grundentgelt": 4_257.00},
+    "EG 12": {"bis 36. Monat": 4_387.00, "nach 36. Monat": 4_872.00},
+    "EG 13": {
+        "bis 18. Monat": 4_902.00,
+        "nach 18. Monat": 5_190.50,
+        "nach 36. Monat": 5_766.50,
+    },
+    "EG 14": {
+        "bis 12. Monat": 5_568.50,
+        "nach 12. Monat": 5_917.00,
+        "nach 24. Monat": 6_265.50,
+        "nach 36. Monat": 6_962.50,
+    },
+}
+
+TZUG_B_REF = TARIF_NRW_2025["EG 8"]["Grundentgelt"]
+
+STANDARD_HOURS = 35
+
+@dataclass
+class TarifInputData:
+    entgeltgruppe: str
+    stufe: str
+    wochenstunden: float = 35
+    leistungszulage_pct: float = 0.0
+    sonstige_zulage_pct: float = 0.0
+    tzug_b_pct: float = 18.5
+    urlaubsgeld_pct: float = 72.0
+    transformationsgeld_pct: float = 18.4
+    tzug_a_pct: float = 27.5
+    weihnachtsgeld_pct_base: float = 25.0
+    weihnachtsgeld_pct_max: float = 55.0
+    betriebszugehoerigkeit_monate: int = 0
+    include_transformationsgeld: bool = True
+
+@dataclass
+class TarifResultData:
+    monatsgrund: float
+    zulagen: float
+    monatsgesamt: float
+    tzug_b: float
+    urlaubsgeld: float
+    transformationsgeld: float
+    tzug_a: float
+    weihnachtsgeld: float
+    jahresentgelt: float
+    def asdict(self):
+        return asdict(self)
+
+
+def berechne_nrw_2025(inp: TarifInputData) -> TarifResultData:
+    eg_data = TARIF_NRW_2025.get(inp.entgeltgruppe)
+    if not eg_data:
+        raise ValueError("Unbekannte Entgeltgruppe.")
+    if inp.stufe not in eg_data:
+        raise ValueError(
+            f"Stufe '{inp.stufe}' in {inp.entgeltgruppe} nicht hinterlegt."
+        )
+    grund_tab = eg_data[inp.stufe]
+
+    faktor = inp.wochenstunden / STANDARD_HOURS
+    grund_zeit = grund_tab * faktor
+
+    lz = grund_zeit * inp.leistungszulage_pct / 100
+    sonst = grund_zeit * inp.sonstige_zulage_pct / 100
+    monatsgesamt = grund_zeit + lz + sonst
+
+    tzug_b = TZUG_B_REF * inp.tzug_b_pct / 100 * faktor
+    urlaubsgeld = monatsgesamt * inp.urlaubsgeld_pct / 100
+    transformationsgeld = (
+        monatsgesamt * inp.transformationsgeld_pct / 100
+        if inp.include_transformationsgeld else 0.0
+    )
+    tzug_a = monatsgesamt * inp.tzug_a_pct / 100
+
+    wg_pct = (
+        inp.weihnachtsgeld_pct_max if inp.betriebszugehoerigkeit_monate >= 36
+        else inp.weihnachtsgeld_pct_base
+    )
+    weihnachtsgeld = monatsgesamt * wg_pct / 100
+
+    jahresentgelt = (
+        monatsgesamt * 12 +
+        tzug_b + urlaubsgeld + transformationsgeld + tzug_a + weihnachtsgeld
+    )
+
+    return TarifResultData(
+        monatsgrund=round(grund_zeit, 2),
+        zulagen=round(lz + sonst, 2),
+        monatsgesamt=round(monatsgesamt, 2),
+        tzug_b=round(tzug_b, 2),
+        urlaubsgeld=round(urlaubsgeld, 2),
+        transformationsgeld=round(transformationsgeld, 2),
+        tzug_a=round(tzug_a, 2),
+        weihnachtsgeld=round(weihnachtsgeld, 2),
+        jahresentgelt=round(jahresentgelt, 2),
+    )
+
+
+def get_monthly_breakdown(inp: TarifInputData) -> List[Dict[str, Any]]:
+    res = berechne_nrw_2025(inp)
+    base = res.monatsgesamt
+
+    def record(month: str, gross: float, components: List[str]):
+        return {
+            "Monat": month,
+            "Brutto": round(gross, 2),
+            "Bestandteile": ", ".join(components)
+        }
+
+    months: List[Dict[str, Any]] = []
+    months.append(record("Januar", base, ["Grund-/Zulagen"]))
+    months.append(record("Februar", base + res.tzug_b, ["Grund-/Zulagen", "T-ZUG B"]))
+    months.append(record("März", base, ["Grund-/Zulagen"]))
+    months.append(record("April", base, ["Grund-/Zulagen"]))
+    months.append(record("Mai", base, ["Grund-/Zulagen"]))
+    months.append(record("Juni", base + res.urlaubsgeld, ["Grund-/Zulagen", "Urlaubsgeld"]))
+    comps = ["Grund-/Zulagen", "T-ZUG A"]
+    juli_extra = res.tzug_a + res.transformationsgeld
+    if res.transformationsgeld:
+        comps.append("Transformationsgeld")
+    months.append(record("Juli", base + juli_extra, comps))
+    months.append(record("August", base, ["Grund-/Zulagen"]))
+    months.append(record("September", base, ["Grund-/Zulagen"]))
+    months.append(record("Oktober", base, ["Grund-/Zulagen"]))
+    months.append(record("November", base + res.weihnachtsgeld, ["Grund-/Zulagen", "Weihnachtsgeld"]))
+    months.append(record("Dezember", base, ["Grund-/Zulagen"]))
+    return months

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+sqlmodel
+pydantic
+passlib[bcrypt]
+jose
+psycopg2-binary
+pytest

--- a/backend/tests/test_payroll.py
+++ b/backend/tests/test_payroll.py
@@ -1,0 +1,7 @@
+from backend.app.payroll import gross_to_net, PayrollInputData
+
+
+def test_gross_to_net_basic():
+    inp = PayrollInputData(gross=4000)
+    res = gross_to_net(inp)
+    assert res.net > 0

--- a/backend/tests/test_tarif.py
+++ b/backend/tests/test_tarif.py
@@ -1,0 +1,7 @@
+from backend.app.tarif import berechne_nrw_2025, TarifInputData
+
+
+def test_tarif_basic():
+    inp = TarifInputData(entgeltgruppe="EG 1", stufe="Grundentgelt")
+    res = berechne_nrw_2025(inp)
+    assert res.monatsgesamt > 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: finance
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    restart: always
+
+  backend:
+    build: ./backend
+    volumes:
+      - ./backend:/app
+    environment:
+      DATABASE_URL: postgresql://user:password@db:5432/finance
+    depends_on:
+      - db
+
+  frontend:
+    build: ./frontend
+    depends_on:
+      - backend
+
+  traefik:
+    image: traefik:v2.10
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--entrypoints.web.address=:80"
+    ports:
+      - "8877:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - frontend
+
+volumes:
+  db-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine as build
+WORKDIR /app
+COPY package.json tsconfig.json vite.config.ts ./
+COPY src ./src
+COPY index.html ./
+RUN npm install && npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Finance Suite</title>
+    <script type="module" crossorigin src="/src/main.tsx"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "finance-suite-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@chakra-ui/react": "^2.6.1",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "framer-motion": "^10.12.16",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "vite": "^4.4.9",
+    "@vitejs/plugin-react": "^4.0.3"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,31 @@
+import { Box, Container, Heading, Tabs, TabList, TabPanels, Tab, TabPanel, useColorMode, Button } from '@chakra-ui/react';
+import React from 'react';
+import PayrollSettings from './components/PayrollSettings';
+import TarifSettings from './components/TarifSettings';
+import FinanceTable from './components/FinanceTable';
+
+const App = () => {
+  const { toggleColorMode } = useColorMode();
+  return (
+    <Container maxW="container.xl" py={4}>
+      <Box textAlign="right" mb={4}>
+        <Button size="sm" onClick={toggleColorMode}>Toggle Theme</Button>
+      </Box>
+      <Heading mb={4}>Finance Suite</Heading>
+      <Tabs variant="enclosed" isFitted>
+        <TabList>
+          <Tab>Payroll</Tab>
+          <Tab>Tarif</Tab>
+          <Tab>Table</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel><PayrollSettings /></TabPanel>
+          <TabPanel><TarifSettings /></TabPanel>
+          <TabPanel><FinanceTable /></TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Container>
+  );
+};
+
+export default App;

--- a/frontend/src/components/FinanceTable.tsx
+++ b/frontend/src/components/FinanceTable.tsx
@@ -1,0 +1,43 @@
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Button } from '@chakra-ui/react';
+import React, { useState } from 'react';
+
+interface Row {
+  description: string;
+  values: number[];
+}
+
+const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+const FinanceTable = () => {
+  const [rows, setRows] = useState<Row[]>([{ description: 'Income', values: Array(12).fill(0) }]);
+
+  const addRow = () => {
+    setRows([...rows, { description: 'Item', values: Array(12).fill(0) }]);
+  };
+
+  return (
+    <Box overflowX="auto">
+      <Button mb={2} onClick={addRow}>Add row</Button>
+      <Table size="sm" variant="striped">
+        <Thead>
+          <Tr>
+            <Th>Description</Th>
+            {months.map(m => <Th key={m}>{m}</Th>)}
+          </Tr>
+        </Thead>
+        <Tbody>
+          {rows.map((row, rIdx) => (
+            <Tr key={rIdx}>
+              <Td>{row.description}</Td>
+              {row.values.map((v, idx) => (
+                <Td key={idx}>{v}</Td>
+              ))}
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default FinanceTable;

--- a/frontend/src/components/PayrollSettings.tsx
+++ b/frontend/src/components/PayrollSettings.tsx
@@ -1,0 +1,28 @@
+import { Box, Button, Input, FormControl, FormLabel } from '@chakra-ui/react';
+import React, { useState } from 'react';
+
+const PayrollSettings = () => {
+  const [gross, setGross] = useState(4000);
+
+  const handleCalc = async () => {
+    const res = await fetch('/api/payroll/gross-to-net', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gross })
+    });
+    const data = await res.json();
+    console.log(data);
+  };
+
+  return (
+    <Box>
+      <FormControl mb={2}>
+        <FormLabel>Gross (monthly)</FormLabel>
+        <Input type="number" value={gross} onChange={e => setGross(Number(e.target.value))} />
+      </FormControl>
+      <Button onClick={handleCalc}>Calculate</Button>
+    </Box>
+  );
+};
+
+export default PayrollSettings;

--- a/frontend/src/components/TarifSettings.tsx
+++ b/frontend/src/components/TarifSettings.tsx
@@ -1,0 +1,33 @@
+import { Box, Button, Input, FormControl, FormLabel } from '@chakra-ui/react';
+import React, { useState } from 'react';
+
+const TarifSettings = () => {
+  const [entgeltgruppe, setEntgeltgruppe] = useState('EG 1');
+  const [stufe, setStufe] = useState('Grundentgelt');
+
+  const handleCalc = async () => {
+    const res = await fetch('/api/tarif/estimate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ entgeltgruppe, stufe })
+    });
+    const data = await res.json();
+    console.log(data);
+  };
+
+  return (
+    <Box>
+      <FormControl mb={2}>
+        <FormLabel>Entgeltgruppe</FormLabel>
+        <Input value={entgeltgruppe} onChange={e => setEntgeltgruppe(e.target.value)} />
+      </FormControl>
+      <FormControl mb={2}>
+        <FormLabel>Stufe</FormLabel>
+        <Input value={stufe} onChange={e => setStufe(e.target.value)} />
+      </FormControl>
+      <Button onClick={handleCalc}>Calculate</Button>
+    </Box>
+  );
+};
+
+export default TarifSettings;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { ChakraProvider, ColorModeScript } from '@chakra-ui/react';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <ChakraProvider>
+      <ColorModeScript initialColorMode="system" />
+      <App />
+    </ChakraProvider>
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://backend:8000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add FastAPI backend with payroll and tariff calculators
- create React frontend with Chakra UI and TypeScript
- configure Docker Compose with Traefik, PostgreSQL, backend and frontend
- include basic tests using Pytest
- set up GitHub Actions CI workflow
- document compose instructions and adjust port mapping

## Testing
- `python -m pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_683c19df9cb0832c834e45098c427945