### PR TITLE
Fix frontend routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,10 @@ services:
     build: ./frontend
     depends_on:
       - backend
+    labels:
+      - "traefik.http.routers.frontend.rule=PathPrefix(`/`)"
+      - "traefik.http.services.frontend.loadbalancer.server.port=80"
+      - "traefik.http.routers.frontend.entrypoints=web"
 
   traefik:
     image: traefik:v2.10


### PR DESCRIPTION
## Summary
- set labels on frontend service so Traefik routes `/` to the React app

## Testing
- `python -m pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_683c282f7544832c94503a1e96915859