### PR TITLE
Display payroll and tarif results

### DIFF
--- a/frontend/src/components/PayrollSettings.tsx
+++ b/frontend/src/components/PayrollSettings.tsx
@@ -1,8 +1,24 @@
 import { Box, Button, Input, FormControl, FormLabel } from '@chakra-ui/react';
 import React, { useState } from 'react';
 
+interface PayrollResult {
+  net: number;
+  income_tax: number;
+  solidarity: number;
+  church_tax: number;
+  health_employee: number;
+  health_employer: number;
+  care_employee: number;
+  care_employer: number;
+  pension_employee: number;
+  pension_employer: number;
+  unemployment_employee: number;
+  unemployment_employer: number;
+}
+
 const PayrollSettings = () => {
   const [gross, setGross] = useState(4000);
+  const [result, setResult] = useState<PayrollResult | null>(null);
 
   const handleCalc = async () => {
     const res = await fetch('/api/payroll/gross-to-net', {
@@ -10,8 +26,8 @@ const PayrollSettings = () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ gross })
     });
-    const data = await res.json();
-    console.log(data);
+    const data: PayrollResult = await res.json();
+    setResult(data);
   };
 
   return (
@@ -21,6 +37,22 @@ const PayrollSettings = () => {
         <Input type="number" value={gross} onChange={e => setGross(Number(e.target.value))} />
       </FormControl>
       <Button onClick={handleCalc}>Calculate</Button>
+      {result && (
+        <Box mt={4}>
+          <div>Net: {result.net}</div>
+          <div>Income tax: {result.income_tax}</div>
+          <div>Solidarity: {result.solidarity}</div>
+          <div>Church tax: {result.church_tax}</div>
+          <div>Health employee: {result.health_employee}</div>
+          <div>Health employer: {result.health_employer}</div>
+          <div>Care employee: {result.care_employee}</div>
+          <div>Care employer: {result.care_employer}</div>
+          <div>Pension employee: {result.pension_employee}</div>
+          <div>Pension employer: {result.pension_employer}</div>
+          <div>Unemployment employee: {result.unemployment_employee}</div>
+          <div>Unemployment employer: {result.unemployment_employer}</div>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/TarifSettings.tsx
+++ b/frontend/src/components/TarifSettings.tsx
@@ -1,9 +1,22 @@
 import { Box, Button, Input, FormControl, FormLabel } from '@chakra-ui/react';
 import React, { useState } from 'react';
 
+interface TarifResult {
+  monatsgrund: number;
+  zulagen: number;
+  monatsgesamt: number;
+  tzug_b: number;
+  urlaubsgeld: number;
+  transformationsgeld: number;
+  tzug_a: number;
+  weihnachtsgeld: number;
+  jahresentgelt: number;
+}
+
 const TarifSettings = () => {
   const [entgeltgruppe, setEntgeltgruppe] = useState('EG 1');
   const [stufe, setStufe] = useState('Grundentgelt');
+  const [result, setResult] = useState<TarifResult | null>(null);
 
   const handleCalc = async () => {
     const res = await fetch('/api/tarif/estimate', {
@@ -11,8 +24,8 @@ const TarifSettings = () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ entgeltgruppe, stufe })
     });
-    const data = await res.json();
-    console.log(data);
+    const data: TarifResult = await res.json();
+    setResult(data);
   };
 
   return (
@@ -26,6 +39,19 @@ const TarifSettings = () => {
         <Input value={stufe} onChange={e => setStufe(e.target.value)} />
       </FormControl>
       <Button onClick={handleCalc}>Calculate</Button>
+      {result && (
+        <Box mt={4}>
+          <div>Monatsgrund: {result.monatsgrund}</div>
+          <div>Zulagen: {result.zulagen}</div>
+          <div>Monatsgesamt: {result.monatsgesamt}</div>
+          <div>T-ZUG B: {result.tzug_b}</div>
+          <div>Urlaubsgeld: {result.urlaubsgeld}</div>
+          <div>Transformationsgeld: {result.transformationsgeld}</div>
+          <div>T-ZUG A: {result.tzug_a}</div>
+          <div>Weihnachtsgeld: {result.weihnachtsgeld}</div>
+          <div>Jahresentgelt: {result.jahresentgelt}</div>
+        </Box>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- add type definitions for API results
- store calculation results in state
- show returned fields under the forms

## Testing
- `python -m pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_683c2b83aef4832c8070ca95a0a49156