### PR TITLE
Add single page finance table with settings ribbon

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,9 @@
     "@emotion/styled": "^11.11.0",
     "framer-motion": "^10.12.16",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,29 +1,42 @@
 import { Box, Container, Heading, Tabs, TabList, TabPanels, Tab, TabPanel, useColorMode, Button } from '@chakra-ui/react';
-import React from 'react';
+import React, { useState } from 'react';
 import PayrollSettings from './components/PayrollSettings';
 import TarifSettings from './components/TarifSettings';
 import FinanceTable from './components/FinanceTable';
 
 const App = () => {
   const { toggleColorMode } = useColorMode();
+  const [showSettings, setShowSettings] = useState(true);
+  const [gross, setGross] = useState(4000);
+  const [entgeltgruppe, setEntgeltgruppe] = useState('EG 1');
+  const [stufe, setStufe] = useState('Grundentgelt');
+
   return (
     <Container maxW="container.xl" py={4}>
       <Box textAlign="right" mb={4}>
         <Button size="sm" onClick={toggleColorMode}>Toggle Theme</Button>
       </Box>
       <Heading mb={4}>Finance Suite</Heading>
-      <Tabs variant="enclosed" isFitted>
-        <TabList>
-          <Tab>Payroll</Tab>
-          <Tab>Tarif</Tab>
-          <Tab>Table</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel><PayrollSettings /></TabPanel>
-          <TabPanel><TarifSettings /></TabPanel>
-          <TabPanel><FinanceTable /></TabPanel>
-        </TabPanels>
-      </Tabs>
+      <Button size="sm" mb={2} onClick={() => setShowSettings(!showSettings)}>
+        {showSettings ? 'Hide Settings' : 'Show Settings'}
+      </Button>
+      {showSettings && (
+        <Tabs variant="enclosed" mb={4} isFitted>
+          <TabList>
+            <Tab>IGMetall ERA</Tab>
+            <Tab>Net Salary</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              <TarifSettings entgeltgruppe={entgeltgruppe} setEntgeltgruppe={setEntgeltgruppe} stufe={stufe} setStufe={setStufe} />
+            </TabPanel>
+            <TabPanel>
+              <PayrollSettings gross={gross} setGross={setGross} />
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      )}
+      <FinanceTable entgeltgruppe={entgeltgruppe} stufe={stufe} />
     </Container>
   );
 };

--- a/frontend/src/components/FinanceTable.tsx
+++ b/frontend/src/components/FinanceTable.tsx
@@ -1,5 +1,18 @@
 import { Box, Table, Thead, Tbody, Tr, Th, Td, Button, Input } from '@chakra-ui/react';
 import React, { useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
 interface Row {
   description: string;
@@ -8,21 +21,79 @@ interface Row {
 
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
-const FinanceTable = () => {
+interface FinanceTableProps {
+  entgeltgruppe: string;
+  stufe: string;
+}
+
+const FinanceTable = ({ entgeltgruppe, stufe }: FinanceTableProps) => {
   const [rows, setRows] = useState<Row[]>([{ description: 'Income', values: Array(12).fill(0) }]);
+  const [year, setYear] = useState(new Date().getFullYear());
+  const [showChart, setShowChart] = useState(false);
 
   const addRow = () => {
     setRows([...rows, { description: 'Item', values: Array(12).fill(0) }]);
   };
 
+  const headers = months.map(m => <Th key={m}>{m} {year}</Th>);
+
+  const populateIncome = async () => {
+    const tarifRes = await fetch('/api/tarif/estimate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ entgeltgruppe, stufe }),
+    });
+    const tarifData = await tarifRes.json();
+    const gross = tarifData.monatsgesamt;
+    const payRes = await fetch('/api/payroll/gross-to-net', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gross }),
+    });
+    const payData = await payRes.json();
+    const newRows = [...rows];
+    newRows[0].values = Array(12).fill(payData.net);
+    setRows(newRows);
+  };
+
+  const monthlyLeftover: number[] = [];
+  for (let i = 0; i < 12; i++) {
+    const income = rows[0].values[i] || 0;
+    const outcome = rows.slice(1).reduce((s, r) => s + (r.values[i] || 0), 0);
+    const prev = i > 0 ? monthlyLeftover[i - 1] : 0;
+    monthlyLeftover[i] = prev + income - outcome;
+  }
+
+  const chartData = {
+    labels: months,
+    datasets: [
+      {
+        label: 'Leftover',
+        data: monthlyLeftover,
+        borderColor: 'rgb(56,132,255)',
+        backgroundColor: 'rgba(56,132,255,0.2)',
+      },
+    ],
+  };
+
   return (
     <Box overflowX="auto">
-      <Button mb={2} onClick={addRow}>Add row</Button>
+      <Box mb={2} display="flex" gap={2} alignItems="center">
+        <Input width="100px" type="number" value={year} onChange={e => setYear(Number(e.target.value))} />
+        <Button onClick={populateIncome}>Populate Income</Button>
+        <Button onClick={addRow}>Add row</Button>
+        <Button onClick={() => setShowChart(!showChart)}>{showChart ? 'Hide Chart' : 'Show Chart'}</Button>
+      </Box>
+      {showChart && (
+        <Box mb={4}>
+          <Line data={chartData} />
+        </Box>
+      )}
       <Table size="sm" variant="striped">
         <Thead>
           <Tr>
             <Th>Description</Th>
-            {months.map(m => <Th key={m}>{m}</Th>)}
+            {headers}
           </Tr>
         </Thead>
         <Tbody>
@@ -45,6 +116,12 @@ const FinanceTable = () => {
               ))}
             </Tr>
           ))}
+          <Tr>
+            <Td fontWeight="bold">Leftover</Td>
+            {monthlyLeftover.map((v, idx) => (
+              <Td key={idx}>{v.toFixed(2)}</Td>
+            ))}
+          </Tr>
         </Tbody>
       </Table>
     </Box>

--- a/frontend/src/components/PayrollSettings.tsx
+++ b/frontend/src/components/PayrollSettings.tsx
@@ -16,8 +16,12 @@ interface PayrollResult {
   unemployment_employer: number;
 }
 
-const PayrollSettings = () => {
-  const [gross, setGross] = useState(4000);
+interface PayrollSettingsProps {
+  gross: number;
+  setGross: (v: number) => void;
+}
+
+const PayrollSettings = ({ gross, setGross }: PayrollSettingsProps) => {
   const [result, setResult] = useState<PayrollResult | null>(null);
 
   const handleCalc = async () => {

--- a/frontend/src/components/TarifSettings.tsx
+++ b/frontend/src/components/TarifSettings.tsx
@@ -13,9 +13,14 @@ interface TarifResult {
   jahresentgelt: number;
 }
 
-const TarifSettings = () => {
-  const [entgeltgruppe, setEntgeltgruppe] = useState('EG 1');
-  const [stufe, setStufe] = useState('Grundentgelt');
+interface TarifSettingsProps {
+  entgeltgruppe: string;
+  setEntgeltgruppe: (v: string) => void;
+  stufe: string;
+  setStufe: (v: string) => void;
+}
+
+const TarifSettings = ({ entgeltgruppe, setEntgeltgruppe, stufe, setStufe }: TarifSettingsProps) => {
   const [result, setResult] = useState<TarifResult | null>(null);
 
   const handleCalc = async () => {


### PR DESCRIPTION
## Summary
- consolidate UI around a single page table view
- embed ERA and payroll settings in a collapsible ribbon
- allow year selection, income population and chart display
- display monthly leftover values and graph
- update dependencies for charting

## Testing
- `python -m pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_683c2e1061b8832c8eea12333f1bbc29