### PR TITLE
Implement step-based undo and add action logging

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -39,3 +39,14 @@ class Setting(SQLModel, table=True):
     data: Dict[str, Any] = Field(sa_column=Column(SA_JSON))
     ts: datetime = Field(default_factory=datetime.utcnow)
 
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Action logs (chronological list of user actions)
+# ─────────────────────────────────────────────────────────────────────────────
+class ActionLog(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: Optional[int] = Field(default=None, foreign_key="user.id")
+    action: str
+    info: Dict[str, Any] = Field(sa_column=Column(SA_JSON))
+    ts: datetime = Field(default_factory=datetime.utcnow)
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -183,6 +183,7 @@ const App: React.FC = () => {
           year={year}
           onYearChange={setYear}
           tarifInput={tarifInput}
+          payrollInput={payrollInput}
         />
       </VStack>
     </Box>


### PR DESCRIPTION
## Summary
- track user actions with new `ActionLog` model
- log every API operation
- improve FinanceTable independence per year
- create revisions automatically on each edit and enable income autofill
- expose payroll settings to table component

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find sqlmodel)*
- `PYTHONPATH=. pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_683c6153690c832ca2172c0d5e78af84